### PR TITLE
Added &apos; to named XML entities.

### DIFF
--- a/src/normalizers/regex.js
+++ b/src/normalizers/regex.js
@@ -82,6 +82,7 @@ export function gatedEncoder(encoder, ...flagNames) {
 const namedEntities = {
     '&nbsp;': '\u00a0',
     '&amp;' : '&',
+    '&apos;' : "'",
     '&quot;': '"',
     '&lt;'  : '<',
     '&gt;'  : '>'


### PR DESCRIPTION
Not sure if this was a deliberate omission, but adding to support a string which had an `&apos;`

Ref: https://www.w3resource.com/xml/internal-entities.php