### PR TITLE
Added config option to allow text html fragment and added test

### DIFF
--- a/src/filters/html.js
+++ b/src/filters/html.js
@@ -58,6 +58,10 @@ async function findTranslatableStrings(node, c, cb) {
 }
 
 export class HTMLFilter {
+    constructor( params ) {
+        this.allowFragments = params?.allowFragments || false;
+    }
+
     async parseResource({ resource }) {
         const htmlAST = parse(resource);
         const segments = {};
@@ -78,6 +82,7 @@ export class HTMLFilter {
             const translation = await translator(generateGuid(str), str);
             return translation && parseFragment(translation);
         });
-        return serialize(htmlAST);
+        return this.allowFragments? serialize(htmlAST).replace('<html><head></head><body>', '').replace('</body></html>', '') :
+            serialize(htmlAST);
     }
 }

--- a/src/filters/html.js
+++ b/src/filters/html.js
@@ -58,9 +58,6 @@ async function findTranslatableStrings(node, c, cb) {
 }
 
 export class HTMLFilter {
-    constructor( params ) {
-        this.allowFragments = params?.allowFragments || false;
-    }
 
     async parseResource({ resource }) {
         const htmlAST = parse(resource);
@@ -82,7 +79,7 @@ export class HTMLFilter {
             const translation = await translator(generateGuid(str), str);
             return translation && parseFragment(translation);
         });
-        return this.allowFragments && resource.indexOf('<html>')===-1? serialize(htmlAST).replace('<html><head></head><body>', '').replace('</body></html>', '') :
+        return resource.indexOf('<html>')===-1? serialize(htmlAST).replace('<html><head></head><body>', '').replace('</body></html>', '') :
             serialize(htmlAST);
     }
 }

--- a/src/filters/html.js
+++ b/src/filters/html.js
@@ -82,7 +82,7 @@ export class HTMLFilter {
             const translation = await translator(generateGuid(str), str);
             return translation && parseFragment(translation);
         });
-        return this.allowFragments? serialize(htmlAST).replace('<html><head></head><body>', '').replace('</body></html>', '') :
+        return this.allowFragments && resource.indexOf('<html>')===-1? serialize(htmlAST).replace('<html><head></head><body>', '').replace('</body></html>', '') :
             serialize(htmlAST);
     }
 }

--- a/tests/filters/html.test.js
+++ b/tests/filters/html.test.js
@@ -58,7 +58,7 @@ describe('html filter tests', () => {
 });
 
 describe('html filter fragment tests', () => {
-    const resourceFilter = new html.HTMLFilter({allowFragments: true});
+    const resourceFilter = new html.HTMLFilter();
     test('translateResource for a text fragmentreturns string', async () => {
         const resource = 'Hello world';
         const expectedOutput = '***Hello world***';
@@ -71,7 +71,4 @@ describe('html filter fragment tests', () => {
       const translatedRes = await resourceFilter.translateResource({ resource, translator });
       expect(translatedRes).toBe(expectedOutput);
     });
-
-
-
 });

--- a/tests/filters/html.test.js
+++ b/tests/filters/html.test.js
@@ -10,8 +10,6 @@ describe('html filter tests', () => {
     test('html normalizers work as expected', async () => {
         const page = readFileSync(resourceId, 'utf8');
         const pageRes = await resourceFilter.parseResource({resource: page});
-        // const standardDecoders = [ xmlDecoder, xmlEntityDecoder ];
-        console.log(pageRes);
         expect(pageRes)
             .toMatchObject({
                     segments: [
@@ -26,7 +24,7 @@ describe('html filter tests', () => {
                     ]
             });
 
-            const out = getNormalizedString(pageRes.segments[0].str, [xmlDecoder]);
+            const out = getNormalizedString(pageRes.segments[1].str, [xmlDecoder]);
             expect(out)
                 .toMatchObject ([
                     {"t": "bx", "v": "<h1>"},
@@ -55,9 +53,16 @@ describe('html filter tests', () => {
         const resource = readFileSync(resourceId, 'utf8');
         const expectedOutput = readFileSync('tests/files/values-fil/page.html', 'utf8');
         const translatedRes = await resourceFilter.translateResource({ resource, translator });
-        console.log(translatedRes);
         expect(translatedRes).toBe(expectedOutput);
-      });
+    });
+
+    test('translateResource for a text fragmentreturns string', async () => {
+        const resource = 'Hello world';
+        const expectedOutput = '***Hello world***';
+        const translatedRes = await resourceFilter.translateResource({ resource, translator });
+        expect(translatedRes).toBe(expectedOutput);
+    });
+
 
 
 });

--- a/tests/filters/html.test.js
+++ b/tests/filters/html.test.js
@@ -70,7 +70,7 @@ describe('html filter fragment tests', () => {
       const expectedOutput = '<html><head></head><body>***Hello world***</body></html>';
       const translatedRes = await resourceFilter.translateResource({ resource, translator });
       expect(translatedRes).toBe(expectedOutput);
-  });
+    });
 
 
 

--- a/tests/filters/html.test.js
+++ b/tests/filters/html.test.js
@@ -3,6 +3,10 @@ import { getNormalizedString } from '../../src/normalizers/util.js';
 import { xmlDecoder /* , xmlEntityDecoder */ } from '../../src/normalizers/regex.js';
 import { readFileSync } from 'fs';
 
+const translator = async function translate(sid, str) {
+  return sid === 'str1' ? undefined : `***${str}***`;
+}
+
 describe('html filter tests', () => {
     const resourceFilter = new html.HTMLFilter();
     const resourceId = 'tests/files/values/page.html';
@@ -45,23 +49,28 @@ describe('html filter tests', () => {
                 ]);
     });
 
-    const translator = async function translate(sid, str) {
-        return sid === 'str1' ? undefined : `***${str}***`;
-    }
-
     test('translateResource returns string', async () => {
         const resource = readFileSync(resourceId, 'utf8');
         const expectedOutput = readFileSync('tests/files/values-fil/page.html', 'utf8');
         const translatedRes = await resourceFilter.translateResource({ resource, translator });
         expect(translatedRes).toBe(expectedOutput);
     });
+});
 
+describe('html filter fragment tests', () => {
+    const resourceFilter = new html.HTMLFilter({allowFragments: true});
     test('translateResource for a text fragmentreturns string', async () => {
         const resource = 'Hello world';
         const expectedOutput = '***Hello world***';
         const translatedRes = await resourceFilter.translateResource({ resource, translator });
         expect(translatedRes).toBe(expectedOutput);
     });
+    test('translateResource for a text fragmentreturns string', async () => {
+      const resource = '<html><head></head><body>Hello world</body></html>';
+      const expectedOutput = '<html><head></head><body>***Hello world***</body></html>';
+      const translatedRes = await resourceFilter.translateResource({ resource, translator });
+      expect(translatedRes).toBe(expectedOutput);
+  });
 
 
 


### PR DESCRIPTION
If an html source fragment contains text only, it should be translated as text only.