### PR TITLE
Expose segment line number in Java resource filter

### DIFF
--- a/src/filters/java.js
+++ b/src/filters/java.js
@@ -2,15 +2,18 @@ import { parseToEntries, stringifyFromEntries } from '@js.properties/properties'
 
 export class JavaPropertiesFilter {
     async parseResource({ resource }) {
-        const parsedResource = parseToEntries(resource, { sep: true, eol: true, all: true, original: true });
+        const parsedResource = parseToEntries(resource, { sep: true, eol: true, all: true, original: true, location: true });
         const segments = [];
         let previousComments = [];
         for (const e of parsedResource) {
             if (e.key && e.sep.trim() === '=') {
+                const location = {startLine: e.location.start.line, endLine: e.location.end.line}
                 const seg = {
                     sid: e.key,
                     str: e.element,
+                    location
                 };
+
                 if (previousComments.length > 0) {
                     const notes = previousComments.join('\n');
                     if (notes.indexOf('DO_NOT_TRANSLATE') === -1) {

--- a/tests/files/values/messages.properties
+++ b/tests/files/values/messages.properties
@@ -1,4 +1,10 @@
 test.hello=Hello
-test.greet=Greetings {0} on {1,date}
-test.params=Param 1 {0}, Param 2 {1,date}, Param 3 {2,time}, Param 4 {3,number,integer}, Param 5 {4,number,currency}
+# Some multi-line
+# comment
+test.withComment=Comment
+
+test.params=Greetings {0} on {1,date}
 test.1paramWithApostrophe=Param's value: {0}
+
+# DO_NOT_TRANSLATE
+test.shouldNotBeIncluded=Goodbye

--- a/tests/files/values/messages.properties
+++ b/tests/files/values/messages.properties
@@ -1,0 +1,4 @@
+test.hello=Hello
+test.greet=Greetings {0} on {1,date}
+test.params=Param 1 {0}, Param 2 {1,date}, Param 3 {2,time}, Param 4 {3,number,integer}, Param 5 {4,number,currency}
+test.1paramWithApostrophe=Param's value: {0}

--- a/tests/filters/java.test.js
+++ b/tests/filters/java.test.js
@@ -11,24 +11,29 @@ describe("java parseResource", () => {
         const messages = await resourceFilter.parseResource({resource});
         expect(messages)
             .toMatchObject({
-                    segments: [
-                      {
-                        "sid": "test.hello",
-                        "str": "Hello",
-                      },
-                      {
-                        "sid": "test.greet",
-                        "str": "Greetings {0} on {1,date}",
-                      },
-                      {
-                        "sid": "test.params",
-                        "str": "Param 1 {0}, Param 2 {1,date}, Param 3 {2,time}, Param 4 {3,number,integer}, Param 5 {4,number,currency}",
-                      },
-                      {
-                        "sid": "test.1paramWithApostrophe",
-                        "str": "Param's value: {0}", 
-                      }
-                    ]
+              segments: [
+                {
+                  "sid": "test.hello",
+                  "str": "Hello",
+                  "location": {"startLine": 1,"endLine": 1}
+                },
+                {
+                  "sid": "test.withComment",
+                  "str": "Comment",
+                  "notes": "# Some multi-line\n# comment",
+                  "location": {"startLine": 4,"endLine": 4}
+                },
+                {
+                  "sid": "test.params",
+                  "str": "Greetings {0} on {1,date}",
+                  "location": {"startLine": 6,"endLine": 6}
+                },
+                {
+                  "sid": "test.1paramWithApostrophe",
+                  "str": "Param's value: {0}",
+                  "location": {"startLine": 7,"endLine": 7}
+                }
+              ]
             });
     });
 });

--- a/tests/filters/java.test.js
+++ b/tests/filters/java.test.js
@@ -1,0 +1,34 @@
+import * as java from "../../src/filters/java";
+import { readFileSync } from 'fs';
+
+describe("java parseResource", () => {
+    const resourceFilter = new java.JavaPropertiesFilter();
+    const resourceId = 'tests/files/values/messages.properties';
+    const resource = readFileSync(resourceId, 'utf8');
+
+
+    test('basic parsing logic', async () => {
+        const messages = await resourceFilter.parseResource({resource});
+        expect(messages)
+            .toMatchObject({
+                    segments: [
+                      {
+                        "sid": "test.hello",
+                        "str": "Hello",
+                      },
+                      {
+                        "sid": "test.greet",
+                        "str": "Greetings {0} on {1,date}",
+                      },
+                      {
+                        "sid": "test.params",
+                        "str": "Param 1 {0}, Param 2 {1,date}, Param 3 {2,time}, Param 4 {3,number,integer}, Param 5 {4,number,currency}",
+                      },
+                      {
+                        "sid": "test.1paramWithApostrophe",
+                        "str": "Param's value: {0}", 
+                      }
+                    ]
+            });
+    });
+});


### PR DESCRIPTION
Expose segment's start and end line numbers in Java resource filter. This is useful when producing segment-specific error messages (e.g., as part of a linter).

I have also not implemented this for other resource filters yet but it should be straightforward if the actual parser exposes that.

Note that the underlying java properties parser [produces columns](https://github.com/jsproperties/properties#Location) in addition to line numbers but I decided to only expose line numbers.

## Testing

Added a basic unit test for java resource parsing which covers the new line logic.