### PR TITLE
Add workflow to test PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+on: [pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '18.x'
+      - run: npm ci
+      - run: npm run test
+      # For some reason zsh installed here does not have "setopt monitor" and fails.
+      #  > test.zsh:setopt:4: can't change option: MONITOR
+      # Either remove that from script or fix zsh issue to enable regression tests.
+      # - run: sudo apt-get install zsh
+      # - run: cd regression; zsh test.zsh


### PR DESCRIPTION
Simple Workflow to run npm tests on each PR. Example run [here](https://github.com/majido/l10nmonster/actions/runs/4538396734/jobs/7997273018).

This does not run regression tests. This seems to be mainly an issue related to limitation of non-interactive zsh and the way that test.zsh is written. I am confident it can be fixed with some adjustment to the test script.