### PR TITLE
Allow illegally structured ARB annotations in i18next resource

### DIFF
--- a/helpers-json/i18next.js
+++ b/helpers-json/i18next.js
@@ -2,10 +2,10 @@
 const flat = require('flat');
 const { regex } = require('@l10nmonster/helpers');
 
-const isArbAnnotations = e => e[0].split('.').slice(-2)[0].startsWith('@');
+const isArbAnnotations = e => e[0].split('.').slice(0, -1).pop()?.startsWith('@') ?? false;
 const validArbAnnotations = new Set(['description', 'type', 'context', 'placeholders', 'screenshot', 'video', 'source_text']);
 const validPluralSuffixes = new Set(['one', 'other', 'zero', 'two', 'few', 'many']);
-const extractArbGroupsRegex = /(?<prefix>.+?\.)?@(?<key>\S+)\.(?<attribute>\S+)/;
+const extractArbGroupsRegex = /(?<prefix>[^\.]+?\.)?@(?<key>[^\.]+)(?:\.(?<attribute>\S+))?/;
 
 function parseResourceAnnotations(resource, enableArbAnnotations) {
     let parsedResource = Object.entries(flat.flatten(resource));

--- a/tests/filters/json.test.js
+++ b/tests/filters/json.test.js
@@ -608,3 +608,43 @@ describe("json translateResource - enableArrays", () => {
         expect(JSON.parse(output)).toEqual(expectedOutput);
     });
 });
+
+describe("Parse illegally structured ARB", () => {
+    global.l10nmonster = {
+        logger: {
+            verbose: console.log
+        }
+    }
+    const resourceFilter = new i18next.Filter({
+        enableArbAnnotations: true,
+    });
+
+    test("parses root ARB key that is illegally structured", async () => {
+        // value for the "@key" should have an object,
+        // but it should not crash even if it doesn't either
+        const resource = {
+            key: "value",
+            "@key": "comment",
+            ns: {
+                key: "value",
+                "@key": "comment",
+                child: {
+                    key: "value",
+                    "@key": "comment",
+                }
+            }
+        }
+        const expectedOutput = {
+            segments: [
+                { sid: "key", str: "value" },
+                { sid: "@key", str: "comment" },
+                { sid: "ns.key", str: "value" },
+                { sid: "ns.@key", str: "comment" },
+                { sid: "ns.child.key", str: "value" },
+                { sid: "ns.child.@key", str: "comment" },
+            ]
+        }
+        const output = await resourceFilter.parseResource({ resource: JSON.stringify(resource) });
+        expect(output).toMatchObject(expectedOutput);
+    })
+})


### PR DESCRIPTION
In order to make the linter to see and warn the illegally structured ARB metadata for IEP-540, the filter needs to
1. not crash on seeing `{ "@key": "string" }`
2. return those keys that look like an ARB metadata as if it was another string.

As you can see in the new unit test, the current implementation fails to do them so our linter cannot see those strings in the parsed resource, thus cannot warn developers about illegally structured ARB.

The PR fixes both of them by editing the filter predicate function and the regular expression so that they remain in the parsed resources as if they are string resources.