### PR TITLE
Fix comments handling in helpers-android/filter

### DIFF
--- a/helpers-android/package.json
+++ b/helpers-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@l10nmonster/helpers-android",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Helpers to deal with Android file formats",
   "main": "index.js",
   "scripts": {

--- a/regression/expected/android/app/src/main/res/values/strings-with-comments.xml
+++ b/regression/expected/android/app/src/main/res/values/strings-with-comments.xml
@@ -1,0 +1,14 @@
+<resources>
+  <!-- PH(%s|$50|Amount from wallet to be applied on hotel booking) -->
+  <string name="included_wallet_balance">Includes %s from Wallet</string>
+    <!-- PH(%1$s|$300|Coverage cap for the price freeze) -->
+  <string name="price_freeze_header_subtitle">If prices go down, you pay the lower price. If prices increase, Hopper covers up to %1$s.</string>
+  <!-- PH(%1$s|$300|Coverage cap for the price freeze) -->
+  <string name="price_freeze_header_subtitle_compliance">You can save up to %1$s when you come back to book. If the price drops, you pay the lower price.</string>
+  <plurals name="rooms_count_with_suffix">
+    <!-- PH(%1$d|1|The number of rooms desired for a hotel search) PH(%2$s|2 Adults|A suffix, in this case the number of adult and children passengers) -->
+    <item quantity="one">%1$d room • %2$s</item>
+    <!-- PH(%1$d|1|The number of rooms desired for a hotel search) PH(%2$s|2 Adults|A suffix, in this case the number of adult and children passengers) -->
+    <item quantity="other">%1$d rooms • %2$s</item>
+  </plurals>
+</resources>

--- a/regression/expected/android/status.json
+++ b/regression/expected/android/status.json
@@ -10,18 +10,18 @@
 						"translatedByQ": {
 							"1": 6
 						},
-						"untranslated": 0,
-						"untranslatedChars": 0,
-						"untranslatedWords": 0,
+						"untranslated": 5,
+						"untranslatedChars": 215,
+						"untranslatedWords": 41,
 						"pending": 0,
 						"pendingWords": 0,
 						"internalRepetitions": 0,
 						"internalRepetitionWords": 0
 					}
 				},
-				"numSources": 1
+				"numSources": 2
 			}
 		}
 	},
-	"numSources": 1
+	"numSources": 2
 }

--- a/regression/mint/android/app/src/main/res/values/strings-with-comments.xml
+++ b/regression/mint/android/app/src/main/res/values/strings-with-comments.xml
@@ -1,0 +1,14 @@
+<resources>
+  <!-- PH(%s|$50|Amount from wallet to be applied on hotel booking) -->
+  <string name="included_wallet_balance">Includes %s from Wallet</string>
+    <!-- PH(%1$s|$300|Coverage cap for the price freeze) -->
+  <string name="price_freeze_header_subtitle">If prices go down, you pay the lower price. If prices increase, Hopper covers up to %1$s.</string>
+  <!-- PH(%1$s|$300|Coverage cap for the price freeze) -->
+  <string name="price_freeze_header_subtitle_compliance">You can save up to %1$s when you come back to book. If the price drops, you pay the lower price.</string>
+  <plurals name="rooms_count_with_suffix">
+    <!-- PH(%1$d|1|The number of rooms desired for a hotel search) PH(%2$s|2 Adults|A suffix, in this case the number of adult and children passengers) -->
+    <item quantity="one">%1$d room • %2$s</item>
+    <!-- PH(%1$d|1|The number of rooms desired for a hotel search) PH(%2$s|2 Adults|A suffix, in this case the number of adult and children passengers) -->
+    <item quantity="other">%1$d rooms • %2$s</item>
+  </plurals>
+</resources>

--- a/regression/mint/android/l10nmonster.cjs
+++ b/regression/mint/android/l10nmonster.cjs
@@ -13,7 +13,7 @@ module.exports = class TachiyomiConfig2 {
 
     constructor() {
         this.source = new adapters.FsSource({
-            globs: [ '**/values/strings.xml' ],
+            globs: [ '**/values/strings*.xml' ],
         });
         this.resourceFilter = new android.Filter({
             comment: 'pre',

--- a/regression/mint/android/package.json
+++ b/regression/mint/android/package.json
@@ -2,7 +2,7 @@
     "name": "android-demo",
     "dependencies": {
         "@l10nmonster/helpers": "^1",
-        "@l10nmonster/helpers-android": "^1",
+        "@l10nmonster/helpers-android": "../../../helpers-android",
         "@l10nmonster/helpers-xliff": "^1",
         "@l10nmonster/helpers-demo": "^1"
     }

--- a/tests/files/values/plurals.xml
+++ b/tests/files/values/plurals.xml
@@ -1,0 +1,8 @@
+<resources>
+  <plurals name="rooms_count_with_suffix">
+    <!-- PH(%1$d|1|The number of rooms desired for a hotel search) PH(%2$s|2 Adults|A suffix, in this case the number of adult and children passengers) -->
+    <item quantity="one">%1$d room • %2$s</item>
+    <!-- PH(%1$d|1|The number of rooms desired for a hotel search) PH(%2$s|2 Adults|A suffix, in this case the number of adult and children passengers) -->
+    <item quantity="other">%1$d rooms • %2$s</item>
+  </plurals>
+</resources>

--- a/tests/files/values/plurals_t9n.xml
+++ b/tests/files/values/plurals_t9n.xml
@@ -1,0 +1,6 @@
+<resources>
+	<plurals name="rooms_count_with_suffix">
+		<item quantity="one">files/values/plurals.xml rooms_count_with_suffix_one %1$d room • %2$s - **Translation**</item>
+		<item quantity="other">files/values/plurals.xml rooms_count_with_suffix_other %1$d rooms • %2$s - **Translation**</item>
+	</plurals>
+</resources>


### PR DESCRIPTION
Plurals with comments for each item throws in parseResource and translateResource. Fix it by handling comments in the for loop.

If you run the unit test with the current main branch, you will see

```
% node node_modules/jest/bin/jest.js
 FAIL  filters/android.test.js
  ● android filter plurals tests › android filter parses plurals with comments

    TypeError: Cannot read properties of undefined (reading 'quantity')

      58 |                         for (const itemNode of resNode.plurals) {
      59 |                             const seg = {
    > 60 |                                 sid: `${resNode[':@'].name}_${itemNode[':@'].quantity}`,
         |                                                                              ^
      61 |                                 isSuffixPluralized: true,
      62 |                                 str: collapseTextNodes(itemNode.item)
      63 |                             };

      at AndroidFilter.parseResource (../helpers-android/filter.js:60:78)
      at Object.<anonymous> (filters/android.test.js:132:45)

  ● android filter plurals tests › translateResource returns string

    TypeError: Cannot read properties of undefined (reading 'quantity')

      115 |                         let dropPlural = false;
      116 |                         for (const itemNode of resNode.plurals) {
    > 117 |                             const translation = await translator(`${resNode[':@'].name}_${itemNode[':@'].quantity}`, collapseTextNodes(itemNode.item));
          |                                                                                                          ^
      118 |                             if (translation === undefined) {
      119 |                                 dropPlural = true;
      120 |                             } else {

      at AndroidFilter.translateResource (../helpers-android/filter.js:117:106)
      at Object.<anonymous> (filters/android.test.js:140:52)
```