### PR TITLE
feat(helpers-googlecloud): allow specifying projectID for BigQuery

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,30 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(grep:*)",
+      "Bash(npm test)",
+      "Bash(npm test:*)",
+      "Bash(find:*)",
+      "Bash(rg:*)",
+      "Bash(./test.zsh:*)",
+      "Bash(npm run test:regression:*)",
+      "Bash(timeout 30 npm run test:regression)",
+      "Bash(pnpm:*)",
+      "Bash(node:*)",
+      "Bash(npx l10n:*)",
+      "Bash(cat:*)",
+      "Bash(ls:*)",
+      "Bash(./l10n.mjs --version)",
+      "Bash(../../../cli/l10n.mjs --version)",
+      "Bash(npx puppeteer browsers:*)",
+      "Bash(npm run install:*)",
+      "Bash(mv:*)",
+      "Bash(mkdir:*)",
+      "Bash(npm install:*)",
+      "Bash(npm run release:*)",
+      "Bash(npm view:*)",
+      "Bash(git tag:*)"
+    ],
+    "deny": []
+  }
+}


### PR DESCRIPTION
The projectID is used for authentication and is also the project that the jobs will run in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added ability to specify a Google Cloud project ID for BigQuery connections, allowing explicit project selection and improved multi-project compatibility while preserving existing defaults.

- Documentation
  - Documented the new configuration option for setting the Google Cloud project ID in the connector configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->