### PR TITLE
Update i18next.js - handle arb detection properly

### DIFF
--- a/helpers-json/i18next.js
+++ b/helpers-json/i18next.js
@@ -135,7 +135,7 @@ export class I18nextFilter {
                     continue;
                 }
                 
-                // Only keep if regex matches and corresponding translation exists
+                // Only keep if regex matches and corresponding translation exists and is not null
                 const match = extractArbGroupsRegex.exec(key);
                 if (match?.groups) {
                     const { prefix = '', key: arbKey } = match.groups;

--- a/helpers-json/i18next.js
+++ b/helpers-json/i18next.js
@@ -8,7 +8,7 @@ import { flattenAndSplitResources, ARB_ANNOTATION_MARKER, arbPlaceholderHandler 
 
 const isArbAnnotations = e => e[0].split('.').some(segment => segment.startsWith(ARB_ANNOTATION_MARKER));
 const validPluralSuffixes = new Set(['one', 'other', 'zero', 'two', 'few', 'many']);
-const extractArbGroupsRegex = /(?<prefix>.+?\.)?@(?<key>\S+)\.(?<attribute>\S+)/;
+const extractArbGroupsRegex = /(?<prefix>.+?\.)?@(?<key>[^.]+)\.(?<attribute>.+)/;
 const defaultArbAnnotationHandlers = {
     description: (_, data) => (data == null ? undefined : data),
     placeholders: (_, data) => (data == null ? undefined : arbPlaceholderHandler(data)),
@@ -140,7 +140,7 @@ export class I18nextFilter {
                 if (match?.groups) {
                     const { prefix = '', key: arbKey } = match.groups;
                     const sid = `${prefix}${arbKey}`;
-                    if (!flatResource[sid]) {
+                    if (!Object.prototype.hasOwnProperty.call(flatResource, sid)) {
                         delete flatResource[key];
                     }
                 } else {

--- a/helpers-json/i18next.js
+++ b/helpers-json/i18next.js
@@ -140,7 +140,7 @@ export class I18nextFilter {
                 if (match?.groups) {
                     const { prefix = '', key: arbKey } = match.groups;
                     const sid = `${prefix}${arbKey}`;
-                    if (!Object.prototype.hasOwnProperty.call(flatResource, sid)) {
+                    if (!Object.prototype.hasOwnProperty.call(flatResource, sid) || flatResource[sid] == null) {
                         delete flatResource[key];
                     }
                 } else {

--- a/helpers-json/i18next.js
+++ b/helpers-json/i18next.js
@@ -142,9 +142,6 @@ export class I18nextFilter {
                     const sid = `${prefix}${arbKey}`;
                     if (!Object.prototype.hasOwnProperty.call(flatResource, sid) || flatResource[sid] == null) {
                         delete flatResource[key];
-                    } else if (attribute.startsWith('placeholders')) {
-                        // Filter out placeholders attribute - only keep description
-                        delete flatResource[key];
                     }
                 } else {
                     // No regex match, can't determine corresponding translation, so delete

--- a/helpers-json/i18next.js
+++ b/helpers-json/i18next.js
@@ -127,7 +127,7 @@ export class I18nextFilter {
         }
         if (this.enableArbAnnotations) {
             for (const entry of Object.entries(flatResource).filter(entry => isArbAnnotations(entry))) {
-                const [key] = entry;
+                const [key, value] = entry;
                 
                 // Always delete if not emitting annotations
                 if (!this.emitArbAnnotations) {
@@ -138,9 +138,12 @@ export class I18nextFilter {
                 // Only keep if regex matches and corresponding translation exists and is not null
                 const match = extractArbGroupsRegex.exec(key);
                 if (match?.groups) {
-                    const { prefix = '', key: arbKey } = match.groups;
+                    const { prefix = '', key: arbKey, attribute } = match.groups;
                     const sid = `${prefix}${arbKey}`;
                     if (!Object.prototype.hasOwnProperty.call(flatResource, sid) || flatResource[sid] == null) {
+                        delete flatResource[key];
+                    } else if (attribute.startsWith('placeholders')) {
+                        // Filter out placeholders attribute - only keep description
                         delete flatResource[key];
                     }
                 } else {

--- a/helpers-json/i18next.js
+++ b/helpers-json/i18next.js
@@ -117,7 +117,7 @@ export class I18nextFilter {
         for (const entry of Object.entries(flatResource)) {
             if (!this.enableArbAnnotations || !isArbAnnotations(entry)) {
                 const translation = await translator(...entry);
-                if (translation === undefined) {
+                if (translation === null) {
                     delete flatResource[entry[0]];
                 } else {
                     flatResource[entry[0]] = translation;

--- a/helpers-json/i18next.js
+++ b/helpers-json/i18next.js
@@ -128,7 +128,6 @@ export class I18nextFilter {
         if (this.enableArbAnnotations) {
             for (const entry of Object.entries(flatResource).filter(entry => isArbAnnotations(entry))) {
                 const [key] = entry;
-                const match = extractArbGroupsRegex.exec(key);
                 
                 // Always delete if not emitting annotations
                 if (!this.emitArbAnnotations) {
@@ -137,6 +136,7 @@ export class I18nextFilter {
                 }
                 
                 // Only keep if regex matches and corresponding translation exists
+                const match = extractArbGroupsRegex.exec(key);
                 if (match?.groups) {
                     const { prefix = '', key: arbKey } = match.groups;
                     const sid = `${prefix}${arbKey}`;

--- a/helpers-json/json.test.js
+++ b/helpers-json/json.test.js
@@ -777,6 +777,12 @@ suite("nested placeholder tests", () => {
                     differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location",
                     "@differentPlaceDropOff": {
                         description: "Message when drop-off differs from pickup for car rentals",
+                        placeholders: {
+                            pickupLocationName: {
+                                example: "Downtown San Francisco",
+                                description: "The name of the pickup location for car rental"
+                            }
+                        }
                     }
                 }
             }
@@ -937,155 +943,4 @@ suite("annotation handler tests", () => {
         const output = await resourceFilter.parseResource({ resource: JSON.stringify(resource) });
         assert.deepEqual(output, expectedOutput);
     })
-})
-
-suite("nested placeholder tests", () => {
-    test("parseResource handles deeply nested placeholders", async () => {
-        const resourceFilter = new i18next.I18nextFilter({
-            enableArbAnnotations: true,
-        });
-        const resource = {
-            recentSearch: {
-                cars: {
-                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location",
-                    "@differentPlaceDropOff": {
-                        description: "Message when drop-off differs from pickup for car rentals",
-                        placeholders: {
-                            pickupLocationName: {
-                                example: "Downtown San Francisco",
-                                description: "The name of the pickup location for car rental"
-                            }
-                        }
-                    }
-                }
-            }
-        };
-        const expectedOutput = {
-            segments: [
-                {
-                    sid: "recentSearch.cars.differentPlaceDropOff",
-                    str: "Drop off at {{pickupLocationName}} instead of pickup location",
-                    notes: `Message when drop-off differs from pickup for car rentals\nPH({{pickupLocationName}}|Downtown San Francisco|The name of the pickup location for car rental)`
-                },
-            ],
-        };
-        const output = await resourceFilter.parseResource({ resource: JSON.stringify(resource) });
-        assert.deepEqual(output, expectedOutput);
-    });
-
-    test("translateResource preserves deeply nested placeholder annotations when emitArbAnnotations is true", async () => {
-        const resourceFilter = new i18next.I18nextFilter({
-            enableArbAnnotations: true,
-            emitArbAnnotations: true,
-        });
-        const translator = async (sid, str) => `${str} - **Translated**`;
-        const resource = {
-            recentSearch: {
-                cars: {
-                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location",
-                    "@differentPlaceDropOff": {
-                        description: "Message when drop-off differs from pickup for car rentals",
-                    }
-                }
-            }
-        };
-        const expectedOutput = {
-            recentSearch: {
-                cars: {
-                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location - **Translated**",
-                    "@differentPlaceDropOff": {
-                        description: "Message when drop-off differs from pickup for car rentals",
-                        placeholders: {
-                            pickupLocationName: {
-                                example: "Downtown San Francisco",
-                                description: "The name of the pickup location for car rental"
-                            }
-                        }
-                    }
-                }
-            }
-        };
-        const output = await resourceFilter.translateResource({
-            resource: JSON.stringify(resource),
-            translator,
-        });
-        assert.deepEqual(JSON.parse(output), expectedOutput);
-    });
-
-    test("translateResource removes deeply nested placeholder annotations when emitArbAnnotations is false", async () => {
-        const resourceFilter = new i18next.I18nextFilter({
-            enableArbAnnotations: true,
-            emitArbAnnotations: false,
-        });
-        const translator = async (sid, str) => `${str} - **Translated**`;
-        const resource = {
-            recentSearch: {
-                cars: {
-                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location",
-                    "@differentPlaceDropOff": {
-                        description: "Message when drop-off differs from pickup for car rentals",
-                        placeholders: {
-                            pickupLocationName: {
-                                example: "Downtown San Francisco",
-                                description: "The name of the pickup location for car rental"
-                            }
-                        }
-                    }
-                }
-            }
-        };
-        const expectedOutput = {
-            recentSearch: {
-                cars: {
-                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location - **Translated**"
-                }
-            }
-        };
-        const output = await resourceFilter.translateResource({
-            resource: JSON.stringify(resource),
-            translator,
-        });
-        assert.deepEqual(JSON.parse(output), expectedOutput);
-    });
-
-    test("translateResource removes nested annotations when translation is null", async () => {
-        const resourceFilter = new i18next.I18nextFilter({
-            enableArbAnnotations: true,
-            emitArbAnnotations: true,
-        });
-        const translator = async (sid, str) => {
-            // Return null for the nested key to test annotation removal
-            return sid === "recentSearch.cars.differentPlaceDropOff" ? null : `${str} - **Translated**`;
-        };
-        const resource = {
-            recentSearch: {
-                cars: {
-                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location",
-                    "@differentPlaceDropOff": {
-                        description: "Message when drop-off differs from pickup for car rentals",
-                        placeholders: {
-                            pickupLocationName: {
-                                example: "Downtown San Francisco",
-                                description: "The name of the pickup location for car rental"
-                            }
-                        }
-                    },
-                    anotherKey: "Another message"
-                }
-            }
-        };
-        const expectedOutput = {
-            recentSearch: {
-                cars: {
-                    differentPlaceDropOff: null,
-                    anotherKey: "Another message - **Translated**"
-                }
-            }
-        };
-        const output = await resourceFilter.translateResource({
-            resource: JSON.stringify(resource),
-            translator,
-        });
-        assert.deepEqual(JSON.parse(output), expectedOutput);
-    });
 })

--- a/helpers-json/json.test.js
+++ b/helpers-json/json.test.js
@@ -531,7 +531,6 @@ suite("json translateResource - if no translation, delete annotations", () => {
             },
         };
         const expectedOutput = {
-            homeSubtitle: null,
             title: "title <strong>Welcome back</strong> to travel. - **Translation**",
             "@title": {
                 description: "header - welcome message of flight flow",
@@ -875,7 +874,6 @@ suite("nested placeholder tests", () => {
         const expectedOutput = {
             recentSearch: {
                 cars: {
-                    differentPlaceDropOff: null,
                     anotherKey: "Another message - **Translated**"
                 }
             }

--- a/helpers-json/json.test.js
+++ b/helpers-json/json.test.js
@@ -938,3 +938,154 @@ suite("annotation handler tests", () => {
         assert.deepEqual(output, expectedOutput);
     })
 })
+
+suite("nested placeholder tests", () => {
+    test("parseResource handles deeply nested placeholders", async () => {
+        const resourceFilter = new i18next.I18nextFilter({
+            enableArbAnnotations: true,
+        });
+        const resource = {
+            recentSearch: {
+                cars: {
+                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location",
+                    "@differentPlaceDropOff": {
+                        description: "Message when drop-off differs from pickup for car rentals",
+                        placeholders: {
+                            pickupLocationName: {
+                                example: "Downtown San Francisco",
+                                description: "The name of the pickup location for car rental"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        const expectedOutput = {
+            segments: [
+                {
+                    sid: "recentSearch.cars.differentPlaceDropOff",
+                    str: "Drop off at {{pickupLocationName}} instead of pickup location",
+                    notes: `Message when drop-off differs from pickup for car rentals\nPH({{pickupLocationName}}|Downtown San Francisco|The name of the pickup location for car rental)`
+                },
+            ],
+        };
+        const output = await resourceFilter.parseResource({ resource: JSON.stringify(resource) });
+        assert.deepEqual(output, expectedOutput);
+    });
+
+    test("translateResource preserves deeply nested placeholder annotations when emitArbAnnotations is true", async () => {
+        const resourceFilter = new i18next.I18nextFilter({
+            enableArbAnnotations: true,
+            emitArbAnnotations: true,
+        });
+        const translator = async (sid, str) => `${str} - **Translated**`;
+        const resource = {
+            recentSearch: {
+                cars: {
+                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location",
+                    "@differentPlaceDropOff": {
+                        description: "Message when drop-off differs from pickup for car rentals",
+                    }
+                }
+            }
+        };
+        const expectedOutput = {
+            recentSearch: {
+                cars: {
+                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location - **Translated**",
+                    "@differentPlaceDropOff": {
+                        description: "Message when drop-off differs from pickup for car rentals",
+                        placeholders: {
+                            pickupLocationName: {
+                                example: "Downtown San Francisco",
+                                description: "The name of the pickup location for car rental"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        const output = await resourceFilter.translateResource({
+            resource: JSON.stringify(resource),
+            translator,
+        });
+        assert.deepEqual(JSON.parse(output), expectedOutput);
+    });
+
+    test("translateResource removes deeply nested placeholder annotations when emitArbAnnotations is false", async () => {
+        const resourceFilter = new i18next.I18nextFilter({
+            enableArbAnnotations: true,
+            emitArbAnnotations: false,
+        });
+        const translator = async (sid, str) => `${str} - **Translated**`;
+        const resource = {
+            recentSearch: {
+                cars: {
+                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location",
+                    "@differentPlaceDropOff": {
+                        description: "Message when drop-off differs from pickup for car rentals",
+                        placeholders: {
+                            pickupLocationName: {
+                                example: "Downtown San Francisco",
+                                description: "The name of the pickup location for car rental"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        const expectedOutput = {
+            recentSearch: {
+                cars: {
+                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location - **Translated**"
+                }
+            }
+        };
+        const output = await resourceFilter.translateResource({
+            resource: JSON.stringify(resource),
+            translator,
+        });
+        assert.deepEqual(JSON.parse(output), expectedOutput);
+    });
+
+    test("translateResource removes nested annotations when translation is null", async () => {
+        const resourceFilter = new i18next.I18nextFilter({
+            enableArbAnnotations: true,
+            emitArbAnnotations: true,
+        });
+        const translator = async (sid, str) => {
+            // Return null for the nested key to test annotation removal
+            return sid === "recentSearch.cars.differentPlaceDropOff" ? null : `${str} - **Translated**`;
+        };
+        const resource = {
+            recentSearch: {
+                cars: {
+                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location",
+                    "@differentPlaceDropOff": {
+                        description: "Message when drop-off differs from pickup for car rentals",
+                        placeholders: {
+                            pickupLocationName: {
+                                example: "Downtown San Francisco",
+                                description: "The name of the pickup location for car rental"
+                            }
+                        }
+                    },
+                    anotherKey: "Another message"
+                }
+            }
+        };
+        const expectedOutput = {
+            recentSearch: {
+                cars: {
+                    differentPlaceDropOff: null,
+                    anotherKey: "Another message - **Translated**"
+                }
+            }
+        };
+        const output = await resourceFilter.translateResource({
+            resource: JSON.stringify(resource),
+            translator,
+        });
+        assert.deepEqual(JSON.parse(output), expectedOutput);
+    });
+})

--- a/helpers-json/json.test.js
+++ b/helpers-json/json.test.js
@@ -731,6 +731,157 @@ suite("Parse illegally structured ARB", () => {
     })
 })
 
+suite("nested placeholder tests", () => {
+    test("parseResource handles deeply nested placeholders", async () => {
+        const resourceFilter = new i18next.I18nextFilter({
+            enableArbAnnotations: true,
+        });
+        const resource = {
+            recentSearch: {
+                cars: {
+                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location",
+                    "@differentPlaceDropOff": {
+                        description: "Message when drop-off differs from pickup for car rentals",
+                        placeholders: {
+                            pickupLocationName: {
+                                example: "Downtown San Francisco",
+                                description: "The name of the pickup location for car rental"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        const expectedOutput = {
+            segments: [
+                {
+                    sid: "recentSearch.cars.differentPlaceDropOff",
+                    str: "Drop off at {{pickupLocationName}} instead of pickup location",
+                    notes: `Message when drop-off differs from pickup for car rentals\nPH({{pickupLocationName}}|Downtown San Francisco|The name of the pickup location for car rental)`
+                },
+            ],
+        };
+        const output = await resourceFilter.parseResource({ resource: JSON.stringify(resource) });
+        assert.deepEqual(output, expectedOutput);
+    });
+
+    test("translateResource preserves deeply nested placeholder annotations when emitArbAnnotations is true", async () => {
+        const resourceFilter = new i18next.I18nextFilter({
+            enableArbAnnotations: true,
+            emitArbAnnotations: true,
+        });
+        const translator = async (sid, str) => `${str} - **Translated**`;
+        const resource = {
+            recentSearch: {
+                cars: {
+                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location",
+                    "@differentPlaceDropOff": {
+                        description: "Message when drop-off differs from pickup for car rentals",
+                    }
+                }
+            }
+        };
+        const expectedOutput = {
+            recentSearch: {
+                cars: {
+                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location - **Translated**",
+                    "@differentPlaceDropOff": {
+                        description: "Message when drop-off differs from pickup for car rentals",
+                        placeholders: {
+                            pickupLocationName: {
+                                example: "Downtown San Francisco",
+                                description: "The name of the pickup location for car rental"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        const output = await resourceFilter.translateResource({
+            resource: JSON.stringify(resource),
+            translator,
+        });
+        assert.deepEqual(JSON.parse(output), expectedOutput);
+    });
+
+    test("translateResource removes deeply nested placeholder annotations when emitArbAnnotations is false", async () => {
+        const resourceFilter = new i18next.I18nextFilter({
+            enableArbAnnotations: true,
+            emitArbAnnotations: false,
+        });
+        const translator = async (sid, str) => `${str} - **Translated**`;
+        const resource = {
+            recentSearch: {
+                cars: {
+                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location",
+                    "@differentPlaceDropOff": {
+                        description: "Message when drop-off differs from pickup for car rentals",
+                        placeholders: {
+                            pickupLocationName: {
+                                example: "Downtown San Francisco",
+                                description: "The name of the pickup location for car rental"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        const expectedOutput = {
+            recentSearch: {
+                cars: {
+                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location - **Translated**"
+                }
+            }
+        };
+        const output = await resourceFilter.translateResource({
+            resource: JSON.stringify(resource),
+            translator,
+        });
+        assert.deepEqual(JSON.parse(output), expectedOutput);
+    });
+
+    test("translateResource removes nested annotations when translation is null", async () => {
+        const resourceFilter = new i18next.I18nextFilter({
+            enableArbAnnotations: true,
+            emitArbAnnotations: true,
+        });
+        const translator = async (sid, str) => {
+            // Return null for the nested key to test annotation removal
+            return sid === "recentSearch.cars.differentPlaceDropOff" ? null : `${str} - **Translated**`;
+        };
+        const resource = {
+            recentSearch: {
+                cars: {
+                    differentPlaceDropOff: "Drop off at {{pickupLocationName}} instead of pickup location",
+                    "@differentPlaceDropOff": {
+                        description: "Message when drop-off differs from pickup for car rentals",
+                        placeholders: {
+                            pickupLocationName: {
+                                example: "Downtown San Francisco",
+                                description: "The name of the pickup location for car rental"
+                            }
+                        }
+                    },
+                    anotherKey: "Another message"
+                }
+            }
+        };
+        const expectedOutput = {
+            recentSearch: {
+                cars: {
+                    differentPlaceDropOff: null,
+                    anotherKey: "Another message - **Translated**"
+                }
+            }
+        };
+        const output = await resourceFilter.translateResource({
+            resource: JSON.stringify(resource),
+            translator,
+        });
+        assert.deepEqual(JSON.parse(output), expectedOutput);
+    });
+})
+
 suite("annotation handler tests", () => {
     test("description handler works", async () => {
         const resourceFilter = new i18next.I18nextFilter({

--- a/regression/expected/react-icu/public/locales/de/translations.json
+++ b/regression/expected/react-icu/public/locales/de/translations.json
@@ -10,6 +10,12 @@
   },
   "nationalIdPlaceholder": "⇥Q9:E̲n̲t̲e̲r̲̟ ̲y̲o̲u̲r̲̟ ̲{{id}}⇤",
   "@nationalIdPlaceholder": {
-    "description": "copy - national ID input placeholder on passenger form"
+    "description": "copy - national ID input placeholder on passenger form",
+    "placeholders": {
+      "id": {
+        "example": "CPF",
+        "description": "Name of a national ID"
+      }
+    }
   }
 }

--- a/regression/expected/react-icu/public/locales/ru/translations.json
+++ b/regression/expected/react-icu/public/locales/ru/translations.json
@@ -10,6 +10,12 @@
   },
   "nationalIdPlaceholder": "⇥Q9:E̲n̲t̲e̲r̲̟ ̲y̲o̲u̲r̲̟ ̲{{id}}⇤",
   "@nationalIdPlaceholder": {
-    "description": "copy - national ID input placeholder on passenger form"
+    "description": "copy - national ID input placeholder on passenger form",
+    "placeholders": {
+      "id": {
+        "example": "CPF",
+        "description": "Name of a national ID"
+      }
+    }
   }
 }


### PR DESCRIPTION
Translate notes with placeholders correctly.

Handle both cases (description and placeholders).  Previously placeholders were not correctly handled.
```
    "foo": {
      "bar": "{{pickupLocationName}} to {{dropOffLocationName}}",
      "@bar": {
        "description": "these are notes",
        "placeholders": {
          "pickupLocationName": {
            "example": "Los Angeles",
            "description": "Name of the location for pickup"
          },
          "dropOffLocationName": {
            "example": "Las Vegas",
            "description": "Name of the location for drop-off"
          }
        }
      },
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of annotated translation keys across all dotted segments; stricter annotation parsing, added default annotation handler, and translation-null now treated as deletion for consistent i18n output (public API unchanged).

* **Tests**
  * Added nested-placeholder tests validating propagation, preservation, and removal of ARB-style placeholder annotations across parse and translate flows.

* **Chores**
  * Added placeholder metadata (example and description) for a national ID placeholder in German and Russian locale translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->