### PR TITLE
feat: implement an approach for mcp extensibility

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -30,10 +30,141 @@ The server then exposes an mcp at `http://localhost:9000/api/ext/mcp` which can 
 
 ## Available Tools
 
-- `translation_status` - Get status of various l10nmonster subsystems inclugin channels, projects, providers, language pairs, jobs, translation memory etc. The caller agent controls which sub-systems to include and the level of details to allow for more efficient use of the context.
+- `status` - Get status of various l10nmonster subsystems including channels, projects, providers, language pairs, jobs, translation memory etc. The caller agent controls which sub-systems to include and the level of details to allow for more efficient use of the context.
 - `source_query` - Query source content and translation memory.
 - `translate` - Translate segments using configured providers.
 
+## Extending MCP with Custom Tools
+
+The MCP server supports a registration-based extensibility pattern, allowing external packages to add custom tools without modifying the core MCP package. This mirrors the `ServeAction.registerExtension` pattern used by the L10n Monster server.
+
+### Creating a Custom Tool
+
+Custom tools extend the `McpTool` base class and follow the same conventions as built-in tools:
+
+```javascript
+import { McpTool, McpInputError } from '@l10nmonster/mcp';
+import { z } from 'zod';
+
+export class MyCustomTool extends McpTool {
+    static metadata = {
+        name: 'my_custom_tool',
+        description: 'Does something custom with translation data',
+        inputSchema: z.object({
+            channelId: z.string().describe('Channel ID to process'),
+            option: z.string().optional().default('default').describe('Optional processing option')
+        })
+    };
+
+    static async execute(mm, args) {
+        // Access MonsterManager methods directly
+        const channel = mm.rm.getChannel(args.channelId);
+        
+        if (!channel) {
+            throw new McpInputError(`Channel "${args.channelId}" not found`, {
+                hints: [`Available channels: ${mm.rm.channelIds.join(', ')}`]
+            });
+        }
+
+        // Return structured data
+        return {
+            channelId: args.channelId,
+            result: 'processed',
+            option: args.option
+        };
+    }
+}
+```
+
+### Registering Custom Tools
+
+Register your custom tools in your `l10nmonster.config.mjs` before calling `serve.registerExtension`:
+
+```javascript
+import config from '@l10nmonster/core';
+import serve from '@l10nmonster/server';
+import { createMcpRoutes, registerTool } from '@l10nmonster/mcp';
+import { MyCustomTool } from './my-custom-tool.js';
+
+// Register custom MCP tools
+registerTool(MyCustomTool);
+
+// Register MCP routes with the server
+serve.registerExtension('mcp', createMcpRoutes);
+
+export default config.l10nMonster(import.meta.dirname)
+    .action(serve);
+```
+
+### Tool Registration in Helper Packages
+
+Helper packages can export their MCP tools for registration by consumers:
+
+```javascript
+// In @l10nmonster/helpers-custom/index.js
+export { MyCustomTool } from './mcpTools/MyCustomTool.js';
+
+// In l10nmonster.config.mjs
+import { registerTool } from '@l10nmonster/mcp';
+import { MyCustomTool } from '@l10nmonster/helpers-custom';
+
+registerTool(MyCustomTool);
+```
+
+### Tool Override
+
+Registered tools can override built-in tools by using the same tool name. This allows customization of default behavior:
+
+```javascript
+import { McpTool } from '@l10nmonster/mcp';
+import { z } from 'zod';
+
+// Override the built-in 'status' tool with custom implementation
+export class CustomStatusTool extends McpTool {
+    static metadata = {
+        name: 'status', // Same name as built-in tool
+        description: 'Custom status implementation',
+        inputSchema: z.object({
+            // Custom schema
+        })
+    };
+
+    static async execute(mm, args) {
+        // Custom implementation
+        return { custom: true };
+    }
+}
+
+registerTool(CustomStatusTool);
+```
+
+### Exported API
+
+The MCP package exports the following for extensibility:
+
+- **`registerTool(ToolClass)`** - Register a custom MCP tool
+- **`McpTool`** - Base class for creating tools
+- **Error types** for structured error handling:
+  - `McpToolError` - Base error with structured metadata
+  - `McpInputError` - Invalid input errors
+  - `McpNotFoundError` - Resource not found errors
+  - `McpProviderError` - Translation provider errors
+
+
+## Examples
+
+The `examples/` directory contains complete examples of custom MCP tools:
+
+- **`custom-tool-example.js`** - Demonstrates creating custom tools including:
+  - `ProjectStatsTool` - Get detailed statistics for a specific project
+  - `QualityInsightsTool` - Analyze translation quality distribution
+
+These examples show best practices for:
+- Extending the `McpTool` base class
+- Defining input schemas with Zod
+- Accessing MonsterManager APIs
+- Handling errors with structured error types
+- Returning well-formatted results
 
 ## Development
 

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -1,1 +1,15 @@
+// Main MCP server integration
 export { createMcpRoutes } from './server.js';
+
+// Tool registration for extensibility
+import { registry } from './tools/registry.js';
+export const registerTool = registry.registerTool.bind(registry);
+
+// Base classes and utilities for creating custom tools
+export { 
+    McpTool,
+    McpToolError,
+    McpInputError,
+    McpNotFoundError,
+    McpProviderError
+} from './tools/mcpTool.js';

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -3,6 +3,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import * as mcpTools from './tools/index.js';
+import { registry } from './tools/registry.js';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
@@ -33,18 +34,27 @@ const serverVersion = await getMcpPackageVersion();
 /**
  * Setup tools on an MCP server instance
  * 
- * Registers all MCP tools exported from ./tools/index.js
+ * Registers all MCP tools from the registry, including:
+ * 1. Built-in tools (auto-registered from ./tools/index.js)
+ * 2. External tools registered via registerTool()
  */
 async function setupToolsOnServer(server, monsterManager) {
-    // Get all tool classes exported from tools/index.js
-    // Filter for classes that have the handler static method and metadata
-    const toolClasses = Object.values(mcpTools).filter(ToolClass => (
+    // Register built-in tools if not already registered
+    const builtInTools = Object.values(mcpTools).filter(ToolClass => (
         ToolClass && 
         typeof ToolClass === 'function' && 
         typeof ToolClass.handler === 'function' && 
         ToolClass.metadata));
 
-    for (const ToolClass of toolClasses) {
+    for (const ToolClass of builtInTools) {
+        const toolName = ToolClass.metadata.name;
+        if (!registry.hasTool(toolName)) {
+            registry.registerTool(ToolClass);
+        }
+    }
+
+    // Register all tools from the registry with the MCP server
+    for (const ToolClass of registry.getAllTools()) {
         const { name, description, inputSchema } = ToolClass.metadata;
         const handler = ToolClass.handler(monsterManager);
         

--- a/mcp/tests/integration.test.js
+++ b/mcp/tests/integration.test.js
@@ -1,0 +1,215 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { registerTool, McpTool, McpInputError } from '../index.js';
+import { registry } from '../tools/registry.js';
+import { z } from 'zod';
+
+// Create a custom tool for testing
+class CustomTestTool extends McpTool {
+    static metadata = {
+        name: 'custom_test_tool',
+        description: 'A custom tool for integration testing',
+        inputSchema: z.object({
+            message: z.string().describe('A test message')
+        })
+    };
+
+    static async execute(mm, args) {
+        return {
+            tool: 'custom_test_tool',
+            message: args.message,
+            timestamp: new Date().toISOString()
+        };
+    }
+}
+
+// Create a tool that overrides a built-in tool name
+class OverrideStatusTool extends McpTool {
+    static metadata = {
+        name: 'status',
+        description: 'Custom status tool override',
+        inputSchema: z.object({})
+    };
+
+    static async execute() {
+        return { custom: true, overridden: true };
+    }
+}
+
+describe('MCP Integration Tests', () => {
+    beforeEach(() => {
+        registry.clear();
+    });
+
+    it('should allow registering and using custom tools', async () => {
+        // Register the custom tool
+        registerTool(CustomTestTool);
+        
+        // Verify it's registered
+        assert.strictEqual(registry.hasTool('custom_test_tool'), true);
+        
+        // Get the tool and create a handler
+        const ToolClass = registry.getTool('custom_test_tool');
+        const handler = ToolClass.handler({});
+        
+        // Execute the handler
+        const result = await handler({ message: 'Hello from custom tool' });
+        
+        // Verify the result
+        assert.ok(result.content);
+        assert.strictEqual(result.content[0].type, 'text');
+        const data = JSON.parse(result.content[0].text);
+        assert.strictEqual(data.tool, 'custom_test_tool');
+        assert.strictEqual(data.message, 'Hello from custom tool');
+    });
+
+    it('should allow overriding built-in tools', () => {
+        // Register an override tool
+        registerTool(OverrideStatusTool);
+        
+        // Verify it's registered with the same name
+        assert.strictEqual(registry.hasTool('status'), true);
+        
+        // Get the tool and verify it's the override
+        const ToolClass = registry.getTool('status');
+        assert.strictEqual(ToolClass.metadata.description, 'Custom status tool override');
+    });
+
+    it('should handle tool execution errors gracefully', async () => {
+        class ErrorTool extends McpTool {
+            static metadata = {
+                name: 'error_tool',
+                description: 'Tool that throws errors',
+                inputSchema: z.object({
+                    shouldError: z.boolean()
+                })
+            };
+
+            static async execute(mm, args) {
+                if (args.shouldError) {
+                    throw new McpInputError('Test error', {
+                        hints: ['Try setting shouldError to false']
+                    });
+                }
+                return { success: true };
+            }
+        }
+
+        registerTool(ErrorTool);
+        
+        const ToolClass = registry.getTool('error_tool');
+        const handler = ToolClass.handler({});
+        
+        // Execute with error
+        const errorResult = await handler({ shouldError: true });
+        
+        // Verify error response
+        assert.strictEqual(errorResult.isError, true);
+        assert.ok(errorResult.content);
+        assert.ok(errorResult.content[0].text.includes('Test error'));
+        
+        // Execute without error
+        const successResult = await handler({ shouldError: false });
+        
+        // Verify success response
+        assert.strictEqual(successResult.isError, undefined);
+        const data = JSON.parse(successResult.content[0].text);
+        assert.strictEqual(data.success, true);
+    });
+
+    it('should validate input schemas', async () => {
+        class StrictTool extends McpTool {
+            static metadata = {
+                name: 'strict_tool',
+                description: 'Tool with strict validation',
+                inputSchema: z.object({
+                    required: z.string().min(1),
+                    optional: z.number().optional()
+                })
+            };
+
+            static async execute(mm, args) {
+                return args;
+            }
+        }
+
+        registerTool(StrictTool);
+        
+        const ToolClass = registry.getTool('strict_tool');
+        const handler = ToolClass.handler({});
+        
+        // Test with missing required field
+        const invalidResult = await handler({});
+        assert.strictEqual(invalidResult.isError, true);
+        
+        // Test with valid input
+        const validResult = await handler({ required: 'test' });
+        assert.strictEqual(validResult.isError, undefined);
+        const data = JSON.parse(validResult.content[0].text);
+        assert.strictEqual(data.required, 'test');
+    });
+
+    it('should support multiple tool registrations via function', () => {
+        class Tool1 extends McpTool {
+            static metadata = {
+                name: 'tool_1',
+                description: 'First tool',
+                inputSchema: z.object({})
+            };
+            static async execute() { return { id: 1 }; }
+        }
+
+        class Tool2 extends McpTool {
+            static metadata = {
+                name: 'tool_2',
+                description: 'Second tool',
+                inputSchema: z.object({})
+            };
+            static async execute() { return { id: 2 }; }
+        }
+
+        class Tool3 extends McpTool {
+            static metadata = {
+                name: 'tool_3',
+                description: 'Third tool',
+                inputSchema: z.object({})
+            };
+            static async execute() { return { id: 3 }; }
+        }
+
+        // Register tools individually
+        registerTool(Tool1);
+        registerTool(Tool2);
+        registerTool(Tool3);
+        
+        // Verify all are registered
+        assert.strictEqual(registry.getAllTools().length, 3);
+        assert.strictEqual(registry.hasTool('tool_1'), true);
+        assert.strictEqual(registry.hasTool('tool_2'), true);
+        assert.strictEqual(registry.hasTool('tool_3'), true);
+    });
+
+    it('should maintain tool isolation between registrations', () => {
+        class IsolatedTool extends McpTool {
+            static metadata = {
+                name: 'isolated',
+                description: 'Isolated tool',
+                inputSchema: z.object({})
+            };
+            static async execute() { return { isolated: true }; }
+        }
+
+        // Register tool
+        registerTool(IsolatedTool);
+        assert.strictEqual(registry.getAllTools().length, 1);
+        
+        // Clear registry
+        registry.clear();
+        assert.strictEqual(registry.getAllTools().length, 0);
+        
+        // Register again
+        registerTool(IsolatedTool);
+        assert.strictEqual(registry.getAllTools().length, 1);
+    });
+});
+

--- a/mcp/tests/registry.test.js
+++ b/mcp/tests/registry.test.js
@@ -1,0 +1,169 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { registry } from '../tools/registry.js';
+import { McpTool } from '../tools/mcpTool.js';
+import { z } from 'zod';
+
+// Mock tool classes for testing
+class TestTool1 extends McpTool {
+    static metadata = {
+        name: 'test_tool_1',
+        description: 'Test tool 1',
+        inputSchema: z.object({})
+    };
+
+    static async execute() {
+        return { result: 'test1' };
+    }
+
+    static handler() {
+        return async () => this.formatResult({ result: 'test1' });
+    }
+}
+
+class TestTool2 extends McpTool {
+    static metadata = {
+        name: 'test_tool_2',
+        description: 'Test tool 2',
+        inputSchema: z.object({})
+    };
+
+    static async execute() {
+        return { result: 'test2' };
+    }
+
+    static handler() {
+        return async () => this.formatResult({ result: 'test2' });
+    }
+}
+
+class OverrideTool extends McpTool {
+    static metadata = {
+        name: 'test_tool_1', // Same name as TestTool1
+        description: 'Override tool',
+        inputSchema: z.object({})
+    };
+
+    static async execute() {
+        return { result: 'override' };
+    }
+
+    static handler() {
+        return async () => this.formatResult({ result: 'override' });
+    }
+}
+
+describe('MCP Registry', () => {
+    beforeEach(() => {
+        // Clear registry before each test
+        registry.clear();
+    });
+
+    it('should register a single tool', () => {
+        registry.registerTool(TestTool1);
+        
+        assert.strictEqual(registry.hasTool('test_tool_1'), true);
+        assert.strictEqual(registry.getTool('test_tool_1'), TestTool1);
+    });
+
+    it('should register multiple tools', () => {
+        registry.registerTools([TestTool1, TestTool2]);
+        
+        assert.strictEqual(registry.hasTool('test_tool_1'), true);
+        assert.strictEqual(registry.hasTool('test_tool_2'), true);
+        
+        const allTools = registry.getAllTools();
+        assert.strictEqual(allTools.length, 2);
+    });
+
+    it('should override existing tool with same name', () => {
+        registry.registerTool(TestTool1);
+        registry.registerTool(OverrideTool);
+        
+        const tool = registry.getTool('test_tool_1');
+        assert.strictEqual(tool, OverrideTool);
+        assert.notStrictEqual(tool, TestTool1);
+    });
+
+    it('should return all registered tools', () => {
+        registry.registerTools([TestTool1, TestTool2]);
+        
+        const allTools = registry.getAllTools();
+        assert.strictEqual(allTools.length, 2);
+        assert.ok(allTools.includes(TestTool1));
+        assert.ok(allTools.includes(TestTool2));
+    });
+
+    it('should return undefined for non-existent tool', () => {
+        const tool = registry.getTool('non_existent');
+        assert.strictEqual(tool, undefined);
+    });
+
+    it('should return false for non-existent tool check', () => {
+        assert.strictEqual(registry.hasTool('non_existent'), false);
+    });
+
+    it('should clear all registered tools', () => {
+        registry.registerTools([TestTool1, TestTool2]);
+        assert.strictEqual(registry.getAllTools().length, 2);
+        
+        registry.clear();
+        assert.strictEqual(registry.getAllTools().length, 0);
+    });
+
+    it('should throw error for invalid tool class', () => {
+        assert.throws(
+            () => registry.registerTool(null),
+            /ToolClass must be a class\/function/
+        );
+        
+        assert.throws(
+            () => registry.registerTool('not a class'),
+            /ToolClass must be a class\/function/
+        );
+    });
+
+    it('should throw error for tool without metadata', () => {
+        class InvalidTool {}
+        
+        assert.throws(
+            () => registry.registerTool(InvalidTool),
+            /must have static metadata property/
+        );
+    });
+
+    it('should throw error for tool without name in metadata', () => {
+        class InvalidTool {
+            static metadata = {
+                description: 'No name'
+            };
+        }
+        
+        assert.throws(
+            () => registry.registerTool(InvalidTool),
+            /metadata must have a string 'name' property/
+        );
+    });
+
+    it('should throw error for tool without handler method', () => {
+        class InvalidTool {
+            static metadata = {
+                name: 'invalid',
+                description: 'No handler'
+            };
+        }
+        
+        assert.throws(
+            () => registry.registerTool(InvalidTool),
+            /must have static handler method/
+        );
+    });
+
+    it('should throw error when registerTools receives non-array', () => {
+        assert.throws(
+            () => registry.registerTools('not an array'),
+            /toolClasses must be an array/
+        );
+    });
+});
+

--- a/mcp/tools/registry.js
+++ b/mcp/tools/registry.js
@@ -1,0 +1,69 @@
+/**
+ * MCP Tool Registry
+ * 
+ * Provides a registration mechanism for extending MCP with custom tools.
+ * External packages can register their own McpTool subclasses which will be
+ * automatically discovered and registered when the MCP server starts.
+ */
+
+class Registry {
+    constructor() {
+        this.registeredTools = new Map(); // toolName -> ToolClass
+    }
+
+    registerTool(ToolClass) {
+        if (!ToolClass || typeof ToolClass !== 'function') {
+            throw new Error('registerTool: ToolClass must be a class/function');
+        }
+
+        if (!ToolClass.metadata || typeof ToolClass.metadata !== 'object') {
+            throw new Error(`registerTool: ${ToolClass.name} must have static metadata property`);
+        }
+
+        if (!ToolClass.metadata.name || typeof ToolClass.metadata.name !== 'string') {
+            throw new Error(`registerTool: ${ToolClass.name} metadata must have a string 'name' property`);
+        }
+
+        if (typeof ToolClass.handler !== 'function') {
+            throw new Error(`registerTool: ${ToolClass.name} must have static handler method`);
+        }
+
+        const toolName = ToolClass.metadata.name;
+        
+        if (this.registeredTools.has(toolName)) {
+            console.warn(`MCP tool "${toolName}" is already registered. Overwriting with new implementation.`);
+        }
+
+        this.registeredTools.set(toolName, ToolClass);
+        console.info(`Registered MCP tool: ${toolName}`);
+    }
+
+    registerTools(toolClasses) {
+        if (!Array.isArray(toolClasses)) {
+            throw new Error('registerTools: toolClasses must be an array');
+        }
+
+        for (const ToolClass of toolClasses) {
+            this.registerTool(ToolClass);
+        }
+    }
+
+    getAllTools() {
+        return Array.from(this.registeredTools.values());
+    }
+
+    getTool(toolName) {
+        return this.registeredTools.get(toolName);
+    }
+
+    hasTool(toolName) {
+        return this.registeredTools.has(toolName);
+    }
+
+    clear() {
+        this.registeredTools.clear();
+    }
+}
+
+export const registry = new Registry();
+


### PR DESCRIPTION
Implements a registration-based extensibility pattern for MCP tools, mirroring the `ServeAction.registerExtension` approach.

### Changes
- Built-in MCP tools (status, source_query, translate) now auto-discovered from `tools/index.js`
- External packages can add custom tools by exporting tool classes
- Tools follow the `McpTool` base class pattern with static `metadata` and `handler` methods
- Includes comprehensive tests (75 tests, 20 suites) and documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled custom tool registration and extensibility for MCP applications.
  * Expanded public API to support tool management and customization.

* **Documentation**
  * Added comprehensive guide for extending MCP with custom tools, including design patterns, schema design, error handling best practices, and practical examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->