### PR TITLE
fix: kitchen sink re-exports default export from server.js

### DIFF
--- a/kitchensink/src/server.js
+++ b/kitchensink/src/server.js
@@ -1,2 +1,4 @@
 // L10n Monster - Server
 export * from '@l10nmonster/server';
+import ServeAction from '@l10nmonster/server';
+export default ServeAction;

--- a/server/index.js
+++ b/server/index.js
@@ -171,3 +171,4 @@ const ServeAction = {
 };
 
 export default ServeAction;
+export { ServeAction };


### PR DESCRIPTION
Changes:
1. server/index.js: Added named export { ServeAction } alongside default
2. kitchensink/src/server.js: Re-exports default for backward compatibility

## Root cause
Per [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export#re-exporting_aggregating)  `export *` does not export `default`.


>There is also export * from "mod", although there's no import * from "mod". This re-exports all named exports from mod as the named exports of the current module, but the default export of mod is not re-exported. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module exports for improved API consistency and clarity across internal dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->